### PR TITLE
fix(ci): pass CODECOV_TOKEN to reusable-build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,3 +22,5 @@ on:
 jobs:
   build:
     uses: notaryproject/notation-core-go/.github/workflows/reusable-build.yml@main
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Depends on https://github.com/notaryproject/notation-core-go/pull/209

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>